### PR TITLE
Remove decimal point for node engine version

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -6,7 +6,7 @@
   "license": "Apache Version 2.0",
   "author": "Google Inc.",
   "engines": {
-    "node": "6.0"
+    "node": "6"
   },
   "scripts": {
     "start": "firebase serve --only functions:dialogflowFirebaseFulfillment",


### PR DESCRIPTION
Using a node version of `6.0` results in

`Error: package.json in functions directory has an engines field which is unsupported. The only valid choices are: {"node": "8"} and {"node": "6"}.`

when running `firebase deploy --only functions:dialogflowFirebaseFulfillment`